### PR TITLE
draft of boot task for hydrox

### DIFF
--- a/boot/build.boot
+++ b/boot/build.boot
@@ -1,0 +1,30 @@
+(set-env!
+  :resource-paths #{"src"}
+  :dependencies   '[[org.clojure/clojure "1.6.0"       :scope "provided"]
+                    [boot/core           "2.1.2"       :scope "provided"]
+                    [adzerk/bootlaces    "0.1.11"      :scope "test"]
+                    [helpshift/hydrox    "0.1.16"]])
+
+(require '[adzerk.bootlaces :refer :all])
+
+(def +version+ "0.1.17-SNAPSHOT")
+
+(bootlaces! +version+)
+
+(task-options!
+  pom {:project     'boot-hydrox
+       :version     +version+
+       :description "Provides hydrox page generation as Boot task"
+       :url         "https://github.com/helpshift/hydrox"
+       :scm         {:url "https://github.com/helpshift/hydrox"}
+       :license     {"Eclipse Public License" "http://www.eclipse.org/legal/epl-v10.html"}})
+
+(deftask dev
+  "Dev process"
+  []
+  (comp
+    (watch)
+    (repl :server true)
+    (pom)
+    (jar)
+    (install)))

--- a/boot/src/boot_hydrox.clj
+++ b/boot/src/boot_hydrox.clj
@@ -1,0 +1,57 @@
+(ns boot-hydrox
+  {:boot/export-tasks true}
+  (:require [clojure.pprint :refer [pprint]]
+            [boot.core :as core]
+            [hydrox.core :as hydrox]
+            [hydrox.core.regulator :as hydrox-regulator]
+            [hara.component :as component]))
+
+(def ^:private deps
+  '[[helpshift/hydrox "0.1.16"]])
+
+(defn- make-regulator
+  "returns a working regulator for a project definition"
+  [proj]
+  (let [folio (-> proj
+                  (hydrox-regulator/create-folio)
+                  (hydrox-regulator/init-folio))
+        state (atom folio)]
+    (hydrox-regulator/regulator state proj)))
+
+(defn- make-proj []
+  (let [env (core/get-env)
+        defaults {:description "unknown"
+                  :license "unknown"
+                  :name "unknown"
+                  :source-paths ["src"]
+                  :test-paths ["test"]
+                  :documentation {}
+                  :root "."
+                  :url "unknown"
+                  :version "unknown"
+                  :dependencies []}
+        config {:description ""
+                :license ""
+                :name ""
+                :source-paths (into [] (env :source-paths))
+                :test-paths (env :test-paths)
+                :documentation (env :documentation)
+                :root (env :root)
+                :url (env :url)
+                :version (env :version)
+                :dependencies (env :dependencies)}]
+    (merge-with #(or %2 %1) defaults config)))
+
+(core/deftask hydrox
+  "hydrox documentation generation"
+  []
+  (let []
+    (core/with-pre-wrap fileset
+      (let [namespaces (core/fileset-namespaces fileset)
+            ns-names (map name namespaces)
+            args (into [] ns-names)
+            proj (make-proj)]
+        (pprint proj)
+        (component/start (make-regulator proj))
+        (hydrox/generate-docs)
+        (core/commit! fileset)))))


### PR DESCRIPTION
As discussed on gitter here's my draft for a boot task.

It will generate documents once, but if called as (comp (hydrox) (wait)) will only echo "CHANGED: file" and not regenerate the docs.
