### PR TITLE
align deps with most recent clojure version

### DIFF
--- a/lein/src/leiningen/hydrox/setup.clj
+++ b/lein/src/leiningen/hydrox/setup.clj
@@ -2,6 +2,7 @@
   (:require [clojure.tools.reader.edn :as edn]
             [clojure.tools.reader.impl.commons :as common]
             [clojure.tools.reader.impl.utils :as utils]
+            [clojure.tools.reader.impl.errors :as read-err]
             [clojure.tools.reader.reader-types :as reader]))
 
 (defn read-keyword
@@ -10,7 +11,7 @@
     (if-not (utils/whitespace? ch)
       (let [token (#'edn/read-token reader ch)]
         (keyword token))
-      (reader/reader-error reader "Invalid token: :"))))
+      (read-err/reader-error reader "Invalid token: :"))))
 
 (defn patch-read-keyword []
   (alter-var-root #'clojure.tools.reader.edn/read-keyword

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/helpshift/hydrox"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [im.chit/jai  "0.2.10"]
                  [im.chit/hara.data      "2.2.17"]
                  [im.chit/hara.io.watch  "2.2.17"]


### PR DESCRIPTION
`reader-error` function was moved to a new namespace, causing problems when hydrox is used in projects that use clojure 1.10.0. I ran `lein hydrox` on this project using clojure 1.10.0 and got no errors.